### PR TITLE
Feature/ignore unstable versions

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -99,13 +99,10 @@ function run(config, done) {
                 var wantedAndAlreadyInstalled = config.wanted && (info.updateTo === info.current);
                 var isDependencyMissing = !info.current;
                 var isUnstable = false;
-                var unstableStrings = ["alpha", "beta", "rc"];
-                var counter;
 
-                for (counter = 0; counter < unstableStrings.length; counter++) {
-                    if (info.updateTo && info.updateTo.indexOf(unstableStrings[counter]) !== -1) {
-                        isUnstable = true;
-                    }
+                // Check for hyphen in version string as this is a prerelease version according to SemVer
+                if (info.updateTo && info.updateTo.indexOf("-") !== -1) {
+                    isUnstable = true;
                 }
 
                 return !(isGitDependeny || wantedAndAlreadyInstalled || isDependencyMissing || isUnstable);

--- a/test/run.js
+++ b/test/run.js
@@ -344,7 +344,7 @@ describe("run()", function () {
         });
 
         describe("testing", function () {
-            describe("if outdated moudles were found", function () {
+            describe("if outdated modules were found", function () {
                 before(setupOutdatedModules(outdatedModules));
                 afterEach(tearDown);
 


### PR DESCRIPTION
This pull requests checks for pre-release version by checking for a hyphen according to the SemVer specification as mentioned in #7.

Tests are still working. As a side effect, this reduced the complexity of the anonymous function and it passes again through ESLint.