### PR TITLE
[RFR] Rollback now use the `--save-exact` option when specified

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -76,7 +76,7 @@ function run(config, done) {
                 }, function (err) {
                     if (err) {
                         emitter.emit("rollback", event);
-                        exec("npm i " + info.name + "@" + info.current + " " + info.saveCmd, function (err) {
+                        exec("npm i " + info.name + "@" + info.current + " " + info.saveCmd + (config.saveExact ? " --save-exact" : ""), function (err) {
                             if (err) {
                                 finish(err);
                                 return;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "updtr",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Update outdated npm modules with zero pain™",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Currently, when a package cannot be updated, the rollback revert it to its previous version but add a `~` (or a `^`), disregarding the `--save-exact` option.