### PR TITLE
Fix exclude handling

### DIFF
--- a/lib/filter.js
+++ b/lib/filter.js
@@ -16,11 +16,9 @@ function isUnstable(info) {
 }
 
 function isExcluded(info, exclude) {
-    var excludedModules = exclude.map(function (name) {
+    return exclude.map(function (name) {
         return name.trim();
-    });
-
-    return info.name.match(new RegExp("^(" + excludedModules.join("|") + ")$"));
+    }).indexOf(info.name) !== -1;
 }
 
 function isCurrentGreaterThanUpdateTo(info) {

--- a/test/run.js
+++ b/test/run.js
@@ -629,7 +629,7 @@ describe("run()", function () {
                         });
                     };
 
-                    run({ cwd: process.cwd(), reporter: reporter, testStdout: true }, done);
+                    run({ cwd: process.cwd(), reporter: reporter, testStdout: true, exclude: "unicons" }, done);
                 });
             });
         });

--- a/test/run.js
+++ b/test/run.js
@@ -289,7 +289,7 @@ var expectedOptionsWithCurrentCountWantedAndSpecifiedRegistry = {
         updateTo: "1.1.5"
     },
     testCmd: "npm test",
-    installCmd: "npm i --registry https://curstom.npm.registry"
+    installCmd: "npm i --registry https://custom.npm.registry"
 };
 
 function tearDown() {
@@ -514,7 +514,7 @@ describe("run()", function () {
                         });
                     };
 
-                    run({ cwd: process.cwd(), reporter: reporter, wanted: true, registry: "https://curstom.npm.registry" }, done);
+                    run({ cwd: process.cwd(), reporter: reporter, wanted: true, registry: "https://custom.npm.registry" }, done);
                 });
             });
 


### PR DESCRIPTION
18f7a8dd968 introduced a broken `isExcluded()`. `match()` returns an
array with matches or null if none was found. So `isExcluded` never
returned false.

We now use `indexOf()` instead of constructing a RegExp.

This fixes #40.