### PR TITLE
Report the names of missing modules

### DIFF
--- a/lib/reporters/default.js
+++ b/lib/reporters/default.js
@@ -3,6 +3,8 @@
 var Spinner = require("cli-spinner").Spinner;
 var unicons = require("unicons");
 
+var util = require("./util");
+
 function defaultReporter(emitter) {
     var currentLine = "";
     var spinner;
@@ -61,8 +63,8 @@ function defaultReporter(emitter) {
     emitter.on("noop", function () {
         finishProgress("No outdated modules found. Are they installed?");
     });
-    emitter.on("modulesMissing", function () {
-        finishProgress("Some modules are not installed. Please install with 'npm install' first.");
+    emitter.on("modulesMissing", function (event) {
+        finishProgress(util.modulesMissingMessage(event));
     });
     emitter.on("outdated", function (event) {
         finishProgress("Found %s outdated module%s", event.total, event.total === 1 ? "" : "s");

--- a/lib/reporters/simple.js
+++ b/lib/reporters/simple.js
@@ -2,6 +2,8 @@
 
 var unicons = require("unicons");
 
+var util = require("./util");
+
 function defaultReporter(emitter) {
     var currentLine = "";
 
@@ -51,8 +53,8 @@ function defaultReporter(emitter) {
     emitter.on("noop", function () {
         finishProgress("No outdated modules found. Are they installed?");
     });
-    emitter.on("modulesMissing", function () {
-        finishProgress("Some modules are not installed. Please install with 'npm install' first.");
+    emitter.on("modulesMissing", function (event) {
+        finishProgress(util.modulesMissingMessage(event));
     });
     emitter.on("outdated", function (event) {
         finishProgress("Found %s outdated module%s", event.total, event.total === 1 ? "" : "s");

--- a/lib/reporters/util.js
+++ b/lib/reporters/util.js
@@ -1,0 +1,15 @@
+"use strict";
+
+function modulesMissingMessage(event) {
+    var moduleList = event.infos.map(function (info) {
+        return info.name;
+    }).join(", ");
+
+    return "Some modules are not installed: " + moduleList +
+           ". Please install with 'npm install' first.";
+}
+
+module.exports = {
+    modulesMissingMessage: modulesMissingMessage
+};
+

--- a/lib/run.js
+++ b/lib/run.js
@@ -38,6 +38,7 @@ function run(config, done) {
         cwd: config.cwd
     });
     exec("npm outdated --json --long --depth=0", function (err, stdout) {
+        var missing;
         var outdated;
         var infos;
         var tasks;
@@ -124,8 +125,11 @@ function run(config, done) {
             })
             .filter(filter(config));
 
-        if (thereAreModulesMissing(infos)) {
-            emitter.emit("modulesMissing");
+        missing = modulesMissing(infos);
+        if (missing.length > 0) {
+            emitter.emit("modulesMissing", {
+                infos: missing
+            });
             finish();
             return;
         }
@@ -155,8 +159,8 @@ function run(config, done) {
     });
 }
 
-function thereAreModulesMissing(infos) {
-    return infos.some(function (info) {
+function modulesMissing(infos) {
+    return infos.filter(function (info) {
         return !info.current;
     });
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Update outdated npm modules with zero pain™",
   "main": "lib/index.js",
   "scripts": {
-    "test": "mocha -R spec",
+    "test": "mocha --recursive -R spec",
     "posttest": "npm run lint",
     "test:watch": "npm run test -- -w -G",
     "coverage": "istanbul cover _mocha -- -R spec",

--- a/test/reporters/util.js
+++ b/test/reporters/util.js
@@ -1,0 +1,25 @@
+"use strict";
+
+var chai = require("chai");
+
+var util = require("../../lib/reporters/util");
+
+var expect = chai.expect;
+
+describe("util", function () {
+    describe("modulesMissingMessage", function () {
+        var modulesMissingMessage = util.modulesMissingMessage;
+
+        it("should contain the list of missing modules", function () {
+            var event = {
+                infos: [{
+                    name: "requests"
+                }, {
+                    name: "leftpad"
+                }]
+            };
+
+            expect(modulesMissingMessage(event)).to.contain("requests, leftpad");
+        });
+    });
+});

--- a/test/run.js
+++ b/test/run.js
@@ -389,8 +389,12 @@ describe("run()", function () {
                         emitter.on("modulesMissing", onModulesMissing);
                     }
                 }, function (err) {
+                    var expectedEvent = {
+                        infos: [sinon.match({ name: "servus.js" })]
+                    };
+
                     expect(onModulesMissing).to.have.been.calledOnce;
-                    expect(onModulesMissing).to.have.been.calledWithExactly();
+                    expect(onModulesMissing).to.have.been.calledWithMatch(expectedEvent);
                     done(err);
                 });
             });


### PR DESCRIPTION
When updating fails due to modules not being installed at all, report
the names of modules to make fixing the problem easier.

Example new error message:

```
Some modules are not installed: express. Please install with 'npm install' first.
```

In my case, running "npm install" doesn't solve the problem because `npm outdated --json --long --depth=0` returns entries without "current" fields for some packages which _are_ installed. That is the real issue I've run into, but adding this information to the error message at least helped me figure out which packages the problem related to.

Fixes #49
