### PR TITLE
Support for yarn outdated multiline stdout

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -119,6 +119,9 @@ function run(config, done) {
             return;
         }
 
+        if (config.useYarn) {
+            stdout = stdout.split('\n')[0];
+        }
         outdated = JSON.parse(stdout);
         if (config.useYarn) {
             if ("data" in outdated && outdated.data.body instanceof Array) {


### PR DESCRIPTION
This fixes Unexpected token { in JSON (#59) for me. Not sure if it's the cleanest approach, but it just drops a {"type":"finished","data":1422} line from stdout.